### PR TITLE
Added post process support for YUY2 format

### DIFF
--- a/ObjectTrackingDemo/ObjectTrackingDemo.Shared/MainPage.xaml.cs
+++ b/ObjectTrackingDemo/ObjectTrackingDemo.Shared/MainPage.xaml.cs
@@ -439,6 +439,8 @@ namespace ObjectTrackingDemo
                         SetRectangleSizeAndPositionBasedOnObjectDetails(
                             ref secondRectangle, ref secondRectangleTranslateTransform,
                             toObjectDetails, imageActualHeight);
+
+                        processingResultImage.Stretch = Stretch.None;
 #endif // WINDOWS_PHONE_APP
                     }
 

--- a/VideoEffect/VideoEffect.Shared/BufferEffect.h
+++ b/VideoEffect/VideoEffect.Shared/BufferEffect.h
@@ -69,6 +69,10 @@ public: // From CAbstractEffect
 	STDMETHODIMP SetProperties(ABI::Windows::Foundation::Collections::IPropertySet *pConfiguration);
     STDMETHODIMP ProcessInput(DWORD dwInputStreamID, IMFSample *pSample, DWORD dwFlags);
 
+#if (WINAPI_FAMILY == WINAPI_FAMILY_PC_APP)
+	STDMETHODIMP ProcessOutput(DWORD dwFlags, DWORD cOutputBufferCount, MFT_OUTPUT_DATA_BUFFER  *pOutputSamples, DWORD *pdwStatus);
+#endif // WINAPI_FAMILY_PC_APP
+
 protected: // From CAbstractEffect
     HRESULT OnProcessOutput(IMFMediaBuffer *pIn, IMFMediaBuffer *pOut);
 

--- a/VideoEffect/VideoEffect.Shared/ImageProcessingUtils.cpp
+++ b/VideoEffect/VideoEffect.Shared/ImageProcessingUtils.cpp
@@ -829,6 +829,47 @@ BYTE* ImageProcessingUtils::mergeFramesNV12(
 
 
 //------------------------------------------------------------------
+// mergeFramesYUY2
+//
+// Merges the two given frame into one at the given X coordinate.
+//------------------------------------------------------------------
+BYTE* ImageProcessingUtils::mergeFramesYUY2(
+	BYTE* leftFrame, BYTE* rightFrame, const UINT32& frameWidth, const UINT32& frameHeight, UINT32& joinX)
+{
+	if (joinX % 2 != 0)
+	{
+		joinX++;
+	}
+
+	if (joinX == 0 || joinX >= frameWidth)
+	{
+		return NULL;
+	}
+
+	const UINT32 frameSizeYUY2 = (frameWidth * frameHeight) << 1;
+	BYTE* mergedFrame = (BYTE*)malloc(frameSizeYUY2 * sizeof(BYTE));
+	BYTE* mergedFrameBegin = mergedFrame;
+	const UINT32 leftSideLength = joinX << 1;
+	const UINT32 rightSideLength = (frameWidth - joinX) << 1;
+	const UINT32 scanWidth = frameWidth << 1;
+
+	for (UINT32 i = 0; i < frameSizeYUY2; i += scanWidth)
+	{
+		CopyMemory(mergedFrame, leftFrame, leftSideLength);
+		mergedFrame += leftSideLength;
+		leftFrame += scanWidth;
+		rightFrame += leftSideLength;
+
+		CopyMemory(mergedFrame, rightFrame, rightSideLength);
+		mergedFrame += rightSideLength;
+		rightFrame += rightSideLength;
+	}
+
+	return mergedFrameBegin;
+}
+
+
+//------------------------------------------------------------------
 // createObjectMap
 //
 //

--- a/VideoEffect/VideoEffect.Shared/ImageProcessingUtils.h
+++ b/VideoEffect/VideoEffect.Shared/ImageProcessingUtils.h
@@ -58,6 +58,10 @@ public: // Static methods
 	static BYTE* mergeFramesNV12(
 		BYTE* leftFrame, BYTE* rightFrame,
 		const UINT32& frameWidth, const UINT32& frameHeight, UINT32& joinX);
+
+	static BYTE* mergeFramesYUY2(
+		BYTE* leftFrame, BYTE* rightFrame,
+		const UINT32& frameWidth, const UINT32& frameHeight, UINT32& joinX);
 	
     static BYTE* copyFrame(BYTE* source, const size_t size);
 

--- a/VideoEffect/VideoEffect.Shared/ObjectFinderEffect.cpp
+++ b/VideoEffect/VideoEffect.Shared/ObjectFinderEffect.cpp
@@ -411,15 +411,6 @@ HRESULT CObjectFinderEffect::OnProcessOutput(IMFMediaBuffer *pIn, IMFMediaBuffer
                 ClearTargetLock();
             }
         }
-
-        // TODO: Temporary until YUV2 is fully supported
-        if (m_messenger->State() == VideoEffectState::Triggered
-            && m_pTransformFn == ChromaFilterTransformImageYUY2)
-        {
-            // Post processing is not currently supported for YUV2.
-            // Thus let's switch back to idle.
-            m_messenger->SetState(VideoEffectState::Idle);
-        }
     }
 
     // Set the data size on the output buffer.


### PR DESCRIPTION
There are two issues which we don't see in the phone build (only happen in the desktop/tablet one when testing with my laptop's integrated cam):
1. No video after adding buffer effect to the video record stream.
2. Adding object finder effect to the preview stream will kill the buffer effect of the video record one.

In order to fix them, I've added some more code as workarounds. Besides some remaining minor bugs, the post process feature basically works now.
